### PR TITLE
Fix regime stats import and docstring

### DIFF
--- a/src/reidfo/core/validation_utils.py
+++ b/src/reidfo/core/validation_utils.py
@@ -22,16 +22,16 @@ def check_axis_is_date(obj: pd.DataFrame | pd.Series, axis: int = 0) -> None:
 # reviewed
 def check_axis_is_string(obj: pd.DataFrame | pd.Series, axis: int = 0) -> None:
     """
-    Validates that either the index (axis=0) or columns (axis=1) of a DataFrame
-    are date-like and convertible to datetime.date.
+    Validate that the specified axis contains only string labels.
 
     :param obj: The DataFrame or Series to check.
-    :param axis: Axis to check — 0 for index, 1 for columns (series only accepts index)
-    :raises ValueError: If conversion to datetime.date fails.
+    :param axis: Axis to check — 0 for index, 1 for columns (Series only accepts index)
+    :raises ValueError: If labels are not strings.
     """
     target = obj.index if axis == 0 else obj.columns
     if target.inferred_type != "string":
-        raise ValueError("All column names must be strings.")
+        name = "index" if axis == 0 else "columns"
+        raise ValueError(f"All {name} must be strings.")
 
 
 # reviewed

--- a/src/reidfo/reid/regime_stats.py
+++ b/src/reidfo/reid/regime_stats.py
@@ -1,7 +1,7 @@
 from typing import Union
 import pandas as pd
 
-from src.reidfo.core.validation_utils import check_axis_is_date, check_axis_is_date
+from src.reidfo.core.validation_utils import check_axis_is_date, check_axis_is_string
 
 
 # reviewed


### PR DESCRIPTION
## Summary
- document check_axis_is_string to verify string labels
- use check_axis_is_string import in RegimeStats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc2b9cf388329aae5e9c4c859dae5